### PR TITLE
Resample: Fix cursor usage

### DIFF
--- a/src/main/java/net/imglib2/script/algorithm/Resample.java
+++ b/src/main/java/net/imglib2/script/algorithm/Resample.java
@@ -146,7 +146,7 @@ public class Resample<N extends NumericType<N>> extends ImgProxy<N>
 			c2.fwd();
 			c2.localize(d); // TODO "localize" seems to indicate the opposite of what it does
 			for (int i=0; i<d.length; i++) p[i] = d[i] * s[i];
-			inter.move(p);
+			inter.setPosition(p);
 			c2.get().set(inter.get());			
 		}
 		return res;


### PR DESCRIPTION
Cursor.move() moves the position relative to the current location. But the passed coordinates in p[] are absolute. Cursor.setPosition() moves to absolute coordinates, what is wanted here.